### PR TITLE
Fullscreen as query string to hide the editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,12 @@ import './styles/global.css'
 export function App() {
   const params = new URLSearchParams(window.location.search)
   const shouldFloat = Boolean(params.get('float'))
+  const isFullscreen = Boolean(params.get('fullscreen'))
 
   return (
     <EditorContentContextProvider>
       <div className="flex flex-col">
-        <MEditor shouldFloat={shouldFloat} showLogo />
+        <MEditor shouldFloat={shouldFloat} showLogo isFullscreen={isFullscreen} />
       </div>
     </EditorContentContextProvider>
   )

--- a/src/components/MEditor/index.tsx
+++ b/src/components/MEditor/index.tsx
@@ -10,6 +10,7 @@ import logoSvg from '../../assets/logo.svg'
 
 interface MEditorProps {
   shouldFloat: boolean
+  isFullscreen: boolean
   showLogo?: boolean
   tabs?: TabButtonProps[] | null
 }
@@ -18,6 +19,7 @@ export function MEditor({
   tabs,
   showLogo = true,
   shouldFloat = false,
+  isFullscreen = false,
 }: MEditorProps) {
   const [selectedTab, setSelectedTab] = useState<Tab>('html')
 
@@ -42,7 +44,7 @@ export function MEditor({
 
   return (
     <motion.div className="w-screen h-screen overflow-hidden relative flex">
-      <div className="flex-1 flex flex-col h-full">
+      <div className={isFullscreen ? `hidden` : `flex-1 flex flex-col h-full`}>
         <nav className="flex items-center gap-1 px-4 py-2 bg-[#13111b]">
           {showLogo && (
             <div className="text-center px-4">
@@ -76,7 +78,7 @@ export function MEditor({
         </main>
       </div>
 
-      <Preview isFloating={shouldFloat} />
+      <Preview isFloating={shouldFloat} fullscreen={isFullscreen} />
     </motion.div>
   )
 }

--- a/src/components/Preview/Header.tsx
+++ b/src/components/Preview/Header.tsx
@@ -8,6 +8,7 @@ export type WindowState = 'minimized' | 'maximized' | 'closed'
 
 interface HeaderProps {
   isFloating: boolean
+  isFullscreen: boolean
   canBeDraggable: boolean
   windowTitle?: string
 
@@ -23,6 +24,7 @@ export function Header({
   onDragStart,
   onWindowStateChanged,
   onLiveReloadToggle,
+  isFullscreen = false,
 }: HeaderProps) {
   const [isLiveReloadEnabled, toggleLiveReload] = useToggle({
     initialValue: true,
@@ -37,6 +39,7 @@ export function Header({
         [`grid-cols-floatingPreviewHeader`]: isFloating,
         [`grid-cols-previewHeader`]: !isFloating,
         [`cursor-move`]: canBeDraggable,
+        [`hidden`]: isFullscreen,
       })}
       onPointerDown={canBeDraggable ? onDragStart : undefined}
     >

--- a/src/components/Preview/index.tsx
+++ b/src/components/Preview/index.tsx
@@ -24,9 +24,10 @@ let previewRenderTimer: NodeJS.Timeout
 
 interface PreviewProps {
   isFloating: boolean
+  fullscreen: boolean
 }
 
-export default function Preview({ isFloating = false }: PreviewProps) {
+export default function Preview({ isFloating = false, fullscreen = false }: PreviewProps) {
   const previewRef = useRef<HTMLDivElement>(null)
   const { app } = useContext(EditorContentContext)
 
@@ -101,6 +102,7 @@ export default function Preview({ isFloating = false }: PreviewProps) {
           [`absolute z-10 rounded-t-lg overflow-auto shadow`]: isFloating,
           [`relative h-full rounded-none`]: !isFloating,
           [`h-8 w-28 overflow-hidden`]: previewWindowState === 'closed',
+          [`flex-1`]: fullscreen,
         })}
         ref={previewRef}
         drag={isFloating}
@@ -136,6 +138,7 @@ export default function Preview({ isFloating = false }: PreviewProps) {
           onDragStart={handlePreviewDragStart}
           onLiveReloadToggle={setIsLiveReloadEnabled}
           onWindowStateChanged={setPreviewWindowState}
+          isFullscreen={fullscreen}
         />
 
         <div


### PR DESCRIPTION
Adding `fullscreen=1` as query string in the URL will hide the Editor and the preview header 